### PR TITLE
Release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to AVM are documented here. The project follows
 [Semantic Versioning](https://semver.org/).
 
-## [0.1.0] - Unreleased
+## [1.0.0] - 2026-07-30
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,7 +90,7 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "avm"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "avm"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.97.1"
 authors = ["Moncefmd"]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -29,7 +29,7 @@ fn avm_process() -> std::process::Command {
 }
 
 #[test]
-fn reports_help_version_and_the_v01_command_surface() {
+fn reports_help_version_and_the_v1_command_surface() {
     avm()
         .assert()
         .success()
@@ -48,7 +48,7 @@ fn reports_help_version_and_the_v01_command_surface() {
         .arg("--version")
         .assert()
         .success()
-        .stdout(predicate::str::contains("avm 0.1.0"));
+        .stdout(predicate::str::contains("avm 1.0.0"));
 
     avm()
         .args(["completion", "powershell"])


### PR DESCRIPTION
## Summary

- set the AVM package and lockfile version to `1.0.0`
- finalize the `1.0.0` changelog entry for 2026-07-30
- update the CLI version regression test

## Why

PR #7 introduced the new AVM product and has been merged. This release commit aligns the package metadata with the intended `v1.0.0` tag so the protected release workflow can verify and publish it.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --all-features --locked -- -D warnings`
- `cargo test --all-targets --locked` (81 tests)
- `cargo build --release --locked`
- release binary reports `avm 1.0.0`
- Cargo metadata reports `1.0.0`
